### PR TITLE
GitHub CLI をインストールする

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ssh-keygen -f secret/id_rsa
 
 # get and save GitHub access token 
 # https://github.com/settings/tokens
+# GitHub CLI need `repo` and `admin:org` permission
 echo "your-access-token" > secret/github_token
 
 # prepare connecting via ssh to myself

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 # generate ssh key for remote in locaol
 ssh-keygen -f secret/id_rsa
 
+# get and save GitHub access token 
+# https://github.com/settings/tokens
+echo "your-access-token" > secret/github_token
+
 # prepare connecting via ssh to myself
 cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 

--- a/common.yml
+++ b/common.yml
@@ -16,6 +16,14 @@
         deb: https://repo.percona.com/apt/percona-release_latest.generic_all.deb
       become: true
 
+    - name: Install GitHub CLI
+      apt:
+        deb:  https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_linux_amd64.deb
+      become: true
+
+    - name: Sign In to GitHub CLI
+      shell: echo {{lookup('file', './secret/github_token') }} | gh auth login --with-token
+
     - name: Install packages
       apt:
         name:

--- a/common.yml
+++ b/common.yml
@@ -22,7 +22,9 @@
       become: true
 
     - name: Sign In to GitHub CLI
-      shell: echo {{lookup('file', './secret/github_token') }} | gh auth login --with-token
+      args:
+        stdin: "{{ lookup('file', './secret/github_token') }}"
+      command: gh auth login --with-token
 
     - name: Install packages
       apt:


### PR DESCRIPTION
## Background
計測結果などを自動でGitHubに掲載したい。

## Solution
GitHub CLI をインストールし、personal tokenを用いて自動ログインさせることで gh コマンドを使えるようにする。

## Memo
`gh auth login --with-token` コマンドは標準入力でトークンを渡してあげる必要があるが、Ansibleでコマンドにファイルの内容から標準入力を与えるやり方が分からなくて困った。苦肉の策でファイルを読んで echo で渡す方法を取っているが、何か他にスタンダードなプラクティスがあれば教えてほしい！